### PR TITLE
fix: scope containers to current compose project

### DIFF
--- a/docker-rollout
+++ b/docker-rollout
@@ -73,6 +73,8 @@ scale() {
 
 main() {
   # "--quiet" returns only container IDs
+  # COMPOSE_FILES must be unquoted to allow multiple files
+  # shellcheck disable=SC2086
   OLD_CONTAINER_ID=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE")
 
   if [[ "$OLD_CONTAINER_ID" == "" ]]; then
@@ -92,6 +94,8 @@ main() {
   echo "==> Scaling '$SERVICE' to 2 instances"
   scale "$SERVICE" 2
 
+  # COMPOSE_FILES must be unquoted to allow multiple files
+  # shellcheck disable=SC2086
   NEW_CONTAINER_ID=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE" | grep -v "$OLD_CONTAINER_ID")
 
   # check if container has healthcheck

--- a/docker-rollout
+++ b/docker-rollout
@@ -72,7 +72,8 @@ scale() {
 }
 
 main() {
-  OLD_CONTAINER_ID=$(docker ps --filter "label=com.docker.compose.service=$SERVICE" --format "{{.ID}}")
+  # "--quiet" returns only container IDs
+  OLD_CONTAINER_ID=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE")
 
   if [[ "$OLD_CONTAINER_ID" == "" ]]; then
     echo "=> Service '$SERVICE' is not running. Starting the service."
@@ -91,7 +92,7 @@ main() {
   echo "==> Scaling '$SERVICE' to 2 instances"
   scale "$SERVICE" 2
 
-  NEW_CONTAINER_ID=$(docker ps --filter "label=com.docker.compose.service=$SERVICE" --format "{{.ID}}" | grep -v "$OLD_CONTAINER_ID")
+  NEW_CONTAINER_ID=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE" | grep -v "$OLD_CONTAINER_ID")
 
   # check if container has healthcheck
   if docker inspect --format='{{json .State.Health}}' "$OLD_CONTAINER_ID" | grep -q "Status"; then


### PR DESCRIPTION
`docker-rollout` would not work if a service with the same name in different compose project is running. Fix it by using `docker-compose ps` to search containers scoped to current compose project, instead of `docker ps`.

Fix #3