### PR TITLE
Add --env-file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Simply replace `docker compose up -d <service>` with `docker rollout <service>` 
 ## Features
 
 - ⏳ Zero downtime deployment for Docker Compose services
-- 🐳 Works with Docker Compose and docker-compose
+- 🐳 Works with Docker Compose and `docker-compose`
 - ❤️ Supports Docker healthchecks out of the box
 
 ## Installation
@@ -44,9 +44,10 @@ $ docker rollout -f docker-compose.yml <service-name>
 
 Options:
 
-- `-f | --file FILE` - (not required) - Path to compose file, can be specified multiple times, as in `docker-compose`.
+- `-f | --file FILE` - (not required) - Path to compose file, can be specified multiple times, as in `docker compose`.
 - `-t | --timeout SECONDS` - (not required) - Timeout in seconds to wait for new container to become healthy, if the container has healthcheck defined in `Dockerfile` or `docker-compose.yml`. Default: 60
 - `-w | --wait SECONDS` - (not required) - Time to wait for new container to be ready if healthcheck is not defined. Default: 10
+- `--env-file FILE` - (not required) - Path to env file, can be specified multiple times, as in `docker compose`.
 
 See examples in [examples](examples) directory for sample `docker-compose.yml` files.
 

--- a/docker-rollout
+++ b/docker-rollout
@@ -39,12 +39,13 @@ Usage: docker rollout [OPTIONS] SERVICE
 Rollout new Compose service version.
 
 Options:
-  -h, --help        Print usage
-  -f, --file FILE   Compose configuration files
-  --env-file FILE   Specify alternate environment files
-  -t, --timeout N   Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
-  -w, --wait N      When no healthcheck is defined, wait for N seconds before
-                    stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
+  -h, --help            Print usage
+  -f, --file FILE       Compose configuration files
+  -t, --timeout N       Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
+  -w, --wait N          When no healthcheck is defined, wait for N seconds
+                        before stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
+      --env-file FILE   Specify an alternate environment file
+
 EOF
 }
 

--- a/docker-rollout
+++ b/docker-rollout
@@ -41,6 +41,7 @@ Rollout new Compose service version.
 Options:
   -h, --help        Print usage
   -f, --file FILE   Compose configuration files
+  --env-file FILE   Specify alternate environment files
   -t, --timeout N   Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
   -w, --wait N      When no healthcheck is defined, wait for N seconds before
                     stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
@@ -66,23 +67,23 @@ scale() {
   local service="$1"
   local replicas="$2"
 
-  # COMPOSE_FILES must be unquoted to allow multiple files
+  # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  $COMPOSE_COMMAND $COMPOSE_FILES up --detach --scale "$service=$replicas" --no-recreate "$service"
+  $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --scale "$service=$replicas" --no-recreate "$service"
 }
 
 main() {
-  # COMPOSE_FILES must be unquoted to allow multiple files
+  # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  if [[ "$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE")" == "" ]]; then
+  if [[ "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")" == "" ]]; then
     echo "==> Service '$SERVICE' is not running. Starting the service."
-    $COMPOSE_COMMAND $COMPOSE_FILES up --detach --no-recreate "$SERVICE"
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
     exit 0
   fi
 
-  # COMPOSE_FILES must be unquoted to allow multiple files
+  # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE")
+  OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")
   readarray -t OLD_CONTAINER_IDS <<<"$OLD_CONTAINER_IDS_STRING"
 
   SCALE=${#OLD_CONTAINER_IDS[@]}
@@ -92,7 +93,7 @@ main() {
 
   # create a variable that contains the IDs of the new containers, but not the old ones
   # shellcheck disable=SC2086
-  NEW_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES ps --quiet "$SERVICE" | grep --invert-match --file <(echo "$OLD_CONTAINER_IDS_STRING"))
+  NEW_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | grep --invert-match --file <(echo "$OLD_CONTAINER_IDS_STRING"))
   readarray -t NEW_CONTAINER_IDS <<<"$NEW_CONTAINER_IDS_STRING"
 
   # check if first container has healthcheck
@@ -153,6 +154,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   -f | --file)
     COMPOSE_FILES="$COMPOSE_FILES -f $2"
+    shift 2
+    ;;
+  --env-file)
+    ENV_FILES="$ENV_FILES --env-file $2"
     shift 2
     ;;
   -t | --timeout)


### PR DESCRIPTION
I use env files a lot in my compose files, and rollout was missing support for them. After https://github.com/docker/compose/pull/10284, `docker compose` even supports multiple `--env-file` instructions.

This PR adds `--env-file` support using the same syntax as `docker compose`.