### PR TITLE
Add -p | --project-name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
 - `-t | --timeout SECONDS` - (not required) - Timeout in seconds to wait for new container to become healthy, if the container has healthcheck defined in `Dockerfile` or `docker-compose.yml`. Default: 60
 - `-w | --wait SECONDS` - (not required) - Time to wait for new container to be ready if healthcheck is not defined. Default: 10
 - `--env-file FILE` - (not required) - Path to env file, can be specified multiple times, as in `docker compose`.
+- `-p | --project-name NAME` - (not required) - Project name.
 
 See examples in [examples](examples) directory for sample `docker-compose.yml` files.
 

--- a/docker-rollout
+++ b/docker-rollout
@@ -39,12 +39,13 @@ Usage: docker rollout [OPTIONS] SERVICE
 Rollout new Compose service version.
 
 Options:
-  -h, --help            Print usage
-  -f, --file FILE       Compose configuration files
-  -t, --timeout N       Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
-  -w, --wait N          When no healthcheck is defined, wait for N seconds
-                        before stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
-      --env-file FILE   Specify an alternate environment file
+  -h, --help                 Print usage
+  -f, --file FILE            Compose configuration files
+  -t, --timeout N            Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
+  -w, --wait N               When no healthcheck is defined, wait for N seconds
+                             before stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
+      --env-file FILE        Specify an alternate environment file
+  -p, --project-name NAME    Project name
 
 EOF
 }
@@ -70,21 +71,21 @@ scale() {
 
   # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --scale "$service=$replicas" --no-recreate "$service"
+  $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES $PROJECT_NAME up --detach --scale "$service=$replicas" --no-recreate "$service"
 }
 
 main() {
   # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  if [[ "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")" == "" ]]; then
+  if [[ "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES $PROJECT_NAME ps --quiet "$SERVICE")" == "" ]]; then
     echo "==> Service '$SERVICE' is not running. Starting the service."
-    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES $PROJECT_NAME up --detach --no-recreate "$SERVICE"
     exit 0
   fi
 
   # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   # shellcheck disable=SC2086
-  OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")
+  OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES $PROJECT_NAME ps --quiet "$SERVICE")
   readarray -t OLD_CONTAINER_IDS <<<"$OLD_CONTAINER_IDS_STRING"
 
   SCALE=${#OLD_CONTAINER_IDS[@]}
@@ -94,7 +95,7 @@ main() {
 
   # create a variable that contains the IDs of the new containers, but not the old ones
   # shellcheck disable=SC2086
-  NEW_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | grep --invert-match --file <(echo "$OLD_CONTAINER_IDS_STRING"))
+  NEW_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES $PROJECT_NAME ps --quiet "$SERVICE" | grep --invert-match --file <(echo "$OLD_CONTAINER_IDS_STRING"))
   readarray -t NEW_CONTAINER_IDS <<<"$NEW_CONTAINER_IDS_STRING"
 
   # check if first container has healthcheck
@@ -159,6 +160,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   --env-file)
     ENV_FILES="$ENV_FILES --env-file $2"
+    shift 2
+    ;;
+  -p | --project-name)
+    PROJECT_NAME="--project-name $2"
     shift 2
     ;;
   -t | --timeout)


### PR DESCRIPTION
Specifying project name is necessary when using a bunch of compose files in a same directory.

This PR adds `-p | --project-name` support using the same syntax as docker compose.