### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ curl https://raw.githubusercontent.com/wowu/docker-rollout/master/docker-rollout
 
 # Make the script executable
 chmod +x ~/.docker/cli-plugins/docker-rollout
+
+# Add user to docker group
+sudo usermod -aG docker $USER
+
+# Refresh group
+newgrp docker
 ```
 
 ## Usage


### PR DESCRIPTION
adds command to add the user in the docker group and applies the new group changes.. Doing this as sometimes the cli isn't able to recognize the plugin even after proper and successfull installation, it also doesn't work with sudo. Performing these two simple steps resolves the issue