### PR TITLE
Fix rollout failing when existing containers are in exited state

### DIFF
--- a/docker-rollout
+++ b/docker-rollout
@@ -84,11 +84,26 @@ scale() {
 
 main() {
   # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
-  if [ -z "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")" ]; then
+  CONTAINERS_JSON=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps -a --format json "$SERVICE")
+
+  # Run the original script when no containers exist
+  if [ -z "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")" ] && [ "$CONTAINERS_JSON" = "[]" ]; then
     echo "==> Service '$SERVICE' is not running. Starting the service."
     $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
     exit 0
   fi
+
+  # Run with --no-recreate param conditionally based on container state
+  echo "$CONTAINERS_JSON" | \
+  jq -r '.[] | "\(.ID) \(.Service) \(.State)"' | \
+  while read -r id service state; do
+    echo "==> Service '$SERVICE' is not running. Starting the service. exit, $state"
+    if [ "$state" == "exited" ]; then
+      $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach "$service"
+    fi
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$service"
+    exit 0
+  done
 
   # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | tr '\n' '|' | sed 's/|$//')

--- a/docker-rollout
+++ b/docker-rollout
@@ -84,26 +84,25 @@ scale() {
 
 main() {
   # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
-  CONTAINERS_JSON=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps -a --format json "$SERVICE")
+  ALL_CONTAINER_IDS=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps -a --quiet "$SERVICE")
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  RUNNING_CONTAINER_IDS=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")
 
   # Run the original script when no containers exist
-  if [ -z "$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")" ] && [ "$CONTAINERS_JSON" = "[]" ]; then
+  if [ -z "$ALL_CONTAINER_IDS" ]; then
     echo "==> Service '$SERVICE' is not running. Starting the service."
+    # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
     $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
     exit 0
   fi
 
-  # Run with --no-recreate param conditionally based on container state
-  echo "$CONTAINERS_JSON" | \
-  jq -r '.[] | "\(.ID) \(.Service) \(.State)"' | \
-  while read -r id service state; do
-    echo "==> Service '$SERVICE' is not running. Starting the service. exit, $state"
-    if [ "$state" == "exited" ]; then
-      $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach "$service"
-    fi
-    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$service"
+  # Containers exist but none are running (all exited) — recreate them
+  if [ -z "$RUNNING_CONTAINER_IDS" ]; then
+    echo "==> Service '$SERVICE' has only exited containers. Recreating."
+    # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach "$SERVICE"
     exit 0
-  done
+  fi
 
   # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
   OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | tr '\n' '|' | sed 's/|$//')

--- a/docker-rollout
+++ b/docker-rollout
@@ -96,11 +96,22 @@ main() {
     exit 0
   fi
 
-  # Containers exist but none are running (all exited) — recreate them
-  if [ -z "$RUNNING_CONTAINER_IDS" ]; then
-    echo "==> Service '$SERVICE' has only exited containers. Recreating."
+  # Identify stopped replicas (present in ps -a but not in ps --quiet)
+  STOPPED_CONTAINER_IDS=""
+  for id in $ALL_CONTAINER_IDS; do
+    if ! echo "$RUNNING_CONTAINER_IDS" | grep -qx "$id"; then
+      STOPPED_CONTAINER_IDS="$STOPPED_CONTAINER_IDS $id"
+    fi
+  done
+
+  # Remove only the stopped replicas and let compose create fresh ones; running containers
+  # are preserved via --no-recreate so the zero-downtime contract isn't broken if config drifted.
+  if [ -n "$STOPPED_CONTAINER_IDS" ]; then
+    echo "==> Service '$SERVICE' has stopped containers:$STOPPED_CONTAINER_IDS. Replacing only those."
+    # shellcheck disable=SC2086 # DOCKER_ARGS and STOPPED_CONTAINER_IDS must be unquoted to allow multiple arguments
+    docker $DOCKER_ARGS rm $STOPPED_CONTAINER_IDS
     # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
-    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach "$SERVICE"
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
     exit 0
   fi
 


### PR DESCRIPTION
**Summary**
Fixes #20

When a service has containers in an exited state, docker rollout would attempt to restart the old (failed) container due to the --no-recreate flag, instead of creating a new container with the updated compose configuration.

This PR adds container state detection before starting services:

- Fetches container state via docker compose ps -a --format json
- If no containers exist at all, behaves as before (starts with --no-recreate)
- If existing containers are in exited state, runs up --detach without --no-recreate, allowing Docker to recreate the container with the updated config
- If containers are running normally, continues with the original --no-recreate behavior


**Problem**

1. Deploy v1 of a service — it crashes and enters Exited state
2. Fix the issue in docker-compose.yml (e.g., remove bad entrypoint)
3. Run docker rollout — it restarts the old broken container instead of creating a new one with the fix